### PR TITLE
Switch port from application flag to env var

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,8 +11,6 @@ import (
 	"github.com/sul-dlss-labs/rialto-entity-resolver/runtime"
 )
 
-// var portFlag = flag.Int("port", 3000, "Port to run this service on")
-
 func main() {
 	server := createServer()
 	defer server.Shutdown()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"flag"
 	"log"
+	"os"
+	"strconv"
 
 	"github.com/sul-dlss-labs/rialto-entity-resolver/generated/restapi"
 	"github.com/sul-dlss-labs/rialto-entity-resolver/handlers"
@@ -10,7 +11,7 @@ import (
 	"github.com/sul-dlss-labs/rialto-entity-resolver/runtime"
 )
 
-var portFlag = flag.Int("port", 3000, "Port to run this service on")
+// var portFlag = flag.Int("port", 3000, "Port to run this service on")
 
 func main() {
 	server := createServer()
@@ -27,10 +28,20 @@ func createServer() *restapi.Server {
 	registry := runtime.NewRegistry(repo)
 	api := handlers.BuildAPI(registry)
 	server := restapi.NewServer(api)
+	portFlag := os.Getenv("PORT")
 
-	// parse flags
-	flag.Parse()
+	// Convert the ENV string to a number
+	port, err := strconv.Atoi(portFlag)
+	if err == nil {
+		port = 3000
+	}
+
+	// A missing env variable will cause a "0" and not an error, so set a default
+	if port == 0 {
+		port = 3000
+	}
+
 	// set the port this service will be run on
-	server.Port = *portFlag
+	server.Port = port
 	return server
 }


### PR DESCRIPTION
This makes the port setting an ENV variable instead of a command line flag in order to be able to set properly during ECS deployment.

Note: this resolves: https://github.com/sul-dlss/rialto/issues/266