### PR TITLE
Use specified port if no error

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,7 +30,7 @@ func createServer() *restapi.Server {
 
 	// Convert the ENV string to a number
 	port, err := strconv.Atoi(portFlag)
-	if err == nil {
+	if err != nil {
 		port = 3000
 	}
 


### PR DESCRIPTION
The condition in the code previously was not handling non-nil error conditions, and was using port 3000 when port *was* successfully converted to an integer.